### PR TITLE
Fix output binary name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ license = "MIT OR Apache-2.0"
 keywords = ["jpeg", "jpg", "pdf"]
 categories = ["multimedia::images", "command-line-utilities"]
 
+[[bin]]
+name = "jpeg-to-pdf"
+path = "src/bin/cli.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
Previously if you ran cargo install, a binary named `cli` would be installed. This PR fixes that by reverting the name to `jpeg-to-pdf`.